### PR TITLE
Email replies

### DIFF
--- a/google-apps-scripts/ledger-checker.gs
+++ b/google-apps-scripts/ledger-checker.gs
@@ -203,6 +203,15 @@ class Ledger {
   }
 
   /**
+   * Sets the timestamp of the old ledger we compared against.
+   *
+   * @param {String} timestamp
+   */
+  setOldLedgerTimestamp(timestamp){
+    this.oldLedgerTimestamp = timestamp;
+  }
+
+  /**
    * Returns each cost code with its last row number.
    * It's returned as an array of cost codes, with each element as
    * [name, lastRowNumber].
@@ -269,6 +278,9 @@ function checkForNewTotals(sheetName) {
   const oldSheet = oldSpreadsheet.getSheetByName("Original");
   let oldLedger = new Ledger(oldSheet.getSheetId());
   oldLedger = getCostCodeTotals(oldSheet, oldLedger);
+
+  // Save timestamp of the old ledger to the new ledger
+  ledger.setOldLedgerTimestamp(oldSheet.getRange("D3").getValue());
 
   // If they're equal then stop
   if (Ledger.compareLedgers(ledger, oldLedger) === true) {


### PR DESCRIPTION
Added the `In-Reply-To` mail header so that the user's email client groups them together. This occurs when:
* Another error email is sent due to subsequent consecutive errors occurring after the first error email.
* More changes occur to the ledger, but the user hasn't updated the original copy that we're comparing against. 