### PR TITLE
Added a script to export society badges data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,4 +140,6 @@ credentials.json
 python-scripts/credentials.json
 python-scripts/token.pickle
 python-scripts/ledger_checker.pickle
+python-scripts/ledger_checker_development.pickle
 python-scripts/*.log
+python-scripts/society-badges-*

--- a/python-scripts/requirements.txt
+++ b/python-scripts/requirements.txt
@@ -1,11 +1,13 @@
 appJar
 Babel
+bs4
 camelot-py
 func-timeout
 google_api_python_client
 google_auth_oauthlib
 html2text
 Jinja2
+lxml
 opencv-python
 protobuf
 pushbullet.py

--- a/python-scripts/society_badges.py
+++ b/python-scripts/society_badges.py
@@ -1,7 +1,13 @@
 """Quick script to get data on society badges across the Guild."""
+import csv
+from datetime import datetime
 
 import requests
 from bs4 import BeautifulSoup
+
+# The badges, as per the text in the a.msl-groupingattributelist-link tags
+ALL_BADGES = ["Accessibility", "Democracy", "Development", "Diversity", "Fundraising", "Inclusivity", "Social",
+              "Sustainability", "welfare"]
 
 
 def main():
@@ -16,10 +22,40 @@ def main():
     print(f"We found {len(all_societies)} societies.")
     if all_societies is None:
         raise Exception("all_societies is None, the structure has changed!")
-    for child in all_societies:
-        societies[child.text] = f"https://www.exeterguild.org{child['href']}"
+    for item in all_societies:
+        societies[item.text] = f"https://www.exeterguild.org{item['href']}"
 
-    print(societies)
+    # Get the number of badges each society has
+    csv_data = []
+    for name, url in societies.items():
+        csv_data.append(get_badges_data(session, name, url))
+
+    # Save to a CSV
+    with open(f"society-badges-{datetime.now().isoformat().replace(':', '_')}.csv", "w", encoding="UTF8",
+              newline="") as file:
+        writer = csv.writer(file)
+        writer.writerow(["Name", "URL"] + ALL_BADGES + ["Total"])
+        writer.writerows(csv_data)
+
+
+def get_badges_data(session: requests.Session, society_name: str, society_url: str) -> list:
+    # Download it
+    badges_got = []
+    page_response = session.get(society_url)
+    page_response.raise_for_status()
+    page_soup = BeautifulSoup(page_response.text, "lxml")
+    page_badges = page_soup.find_all("a", {"class": "msl-groupingattributelist-link"})
+    for item in page_badges:
+        badges_got.append(item.text)
+
+    # Save the result
+    result = [society_name, society_url]
+    for badge in ALL_BADGES:
+        result.append(badge in badges_got)
+    result.append(len(badges_got))
+
+    print(result)
+    return result
 
 
 if __name__ == "__main__":

--- a/python-scripts/society_badges.py
+++ b/python-scripts/society_badges.py
@@ -1,0 +1,26 @@
+"""Quick script to get data on society badges across the Guild."""
+
+import requests
+from bs4 import BeautifulSoup
+
+
+def main():
+    session = requests.Session()
+
+    # Download all societies
+    societies = {}
+    all_response = session.get("https://www.exeterguild.org/societies/")
+    all_response.raise_for_status()
+    all_soup = BeautifulSoup(all_response.text, "lxml")
+    all_societies = all_soup.find_all("a", {"class": "msl-listingitem-link"})
+    print(f"We found {len(all_societies)} societies.")
+    if all_societies is None:
+        raise Exception("all_societies is None, the structure has changed!")
+    for child in all_societies:
+        societies[child.text] = f"https://www.exeterguild.org{child['href']}"
+
+    print(societies)
+
+
+if __name__ == "__main__":
+    main()

--- a/python-scripts/society_badges.py
+++ b/python-scripts/society_badges.py
@@ -31,14 +31,18 @@ def main():
         csv_data.append(get_badges_data(session, name, url))
 
     # Save to a CSV
-    with open(f"society-badges-{datetime.now().isoformat().replace(':', '_')}.csv", "w", encoding="UTF8",
-              newline="") as file:
+    filename = f"society-badges-{datetime.now().isoformat().replace(':', '_')}.csv"
+    with open(filename, "w", encoding="UTF8", newline="") as file:
         writer = csv.writer(file)
         writer.writerow(["Name", "URL"] + ALL_BADGES + ["Total"])
         writer.writerows(csv_data)
 
+    print(f"Saved the results to {filename}.")
+
 
 def get_badges_data(session: requests.Session, society_name: str, society_url: str) -> list:
+    """Get the badge data for the society."""
+
     # Download it
     badges_got = []
     page_response = session.get(society_url)


### PR DESCRIPTION
Extracts the number of badges each society has from its Guild page, and produces a CSV. Sample available here: [society-badges-2022-02-19T17_27_35.952554.csv](https://github.com/cmenon12/contemporary-choir/files/8102667/society-badges-2022-02-19T17_27_35.952554.csv)

Nothing fancy, designed to be run manually, works well. No further improvements available at present (although it'll need to be updated if the Guild page structure or badges available change).

7e763e0fd1edd0f1c366059e58757cfa46bcc9c7
8963f9f32624050ff0be6de01c8ba03fd728ae1c
1d2196ef0c8f72f4d0d0c86e7b9c67600e6594b3