### PR TITLE
Added support for multiple events on the same day & category

### DIFF
--- a/calendar/calendar.gs
+++ b/calendar/calendar.gs
@@ -187,7 +187,7 @@ function checkSheet(startRow = 2) {
 
         // Create new events from the cell
         for (let s = 0; s < sheetEventsSplit.length; s++) {
-          const event = createEventFromCell(sheetEvents[0], sheetEventsSplit[s], getA1Notation(i + startRow, j + 3), allDatesRtfs[i][j + 1], allDatesNotes[i][j + 1], currentCategory)
+          const event = createEventFromCell(sheetEvents[0], sheetEventsSplit[s].trim(), getA1Notation(i + startRow, j + 3), allDatesRtfs[i][j + 1], allDatesNotes[i][j + 1], currentCategory)
           console.log(`Created "${event.getTitle()}" event on ${event.getAllDayStartDate().toLocaleDateString("en-GB")}.`)
         }
 
@@ -204,7 +204,7 @@ function checkSheet(startRow = 2) {
           // Search through the calendar events to try & find one that's the same
           let foundIt = false
           for (let c = 0; c < calEvents[currentCategory].length; c++) {
-            if (compareEvents(calEvents[currentCategory][c], sheetEventsSplit[s], getA1Notation(i + startRow, j + 3), allDatesRtfs[i][j + 1], allDatesNotes[i][j + 1], currentCategory) === true) {
+            if (compareEvents(calEvents[currentCategory][c], sheetEventsSplit[s].trim(), getA1Notation(i + startRow, j + 3), allDatesRtfs[i][j + 1], allDatesNotes[i][j + 1], currentCategory) === true) {
               console.log(`Unchanged "${calEvents[currentCategory][c].getTitle()}" event on ${calEvents[currentCategory][c].getAllDayStartDate().toLocaleDateString("en-GB")}.`)
               foundIt = true
               calToDelete[c] = false
@@ -214,7 +214,7 @@ function checkSheet(startRow = 2) {
 
           // If we didn't find it after iterating then create it
           if (foundIt === false) {
-            const event = createEventFromCell(sheetEvents[0], sheetEventsSplit[s], getA1Notation(i + startRow, j + 3), allDatesRtfs[i][j + 1], allDatesNotes[i][j + 1], currentCategory)
+            const event = createEventFromCell(sheetEvents[0], sheetEventsSplit[s].trim(), getA1Notation(i + startRow, j + 3), allDatesRtfs[i][j + 1], allDatesNotes[i][j + 1], currentCategory)
             console.log(`Created "${event.getTitle()}" event on ${event.getAllDayStartDate().toLocaleDateString("en-GB")}.`)
           }
 

--- a/calendar/calendar.gs
+++ b/calendar/calendar.gs
@@ -40,7 +40,7 @@ function getEventsOnDate(allEvents, dateObj, categories) {
         allEvents[i].deleteEvent();
       }
 
-    // Delete it if it's not an all day event
+      // Delete it if it's not an all day event
     } else if (!allEvents[i].isAllDayEvent()) {
       allEvents[i].deleteEvent();
     }
@@ -145,8 +145,8 @@ function compareEvents(calEvent, cellValue, cellNotation, cellRtf, cellNote, cat
  * @param colNum {number} the column number, from 1
  * @returns {String} the A1 notation of the cell
  */
-function getA1Notation(rowNum, colNum){
-  return `${String.fromCharCode("A".charCodeAt(0)+colNum-1)}${rowNum}`
+function getA1Notation(rowNum, colNum) {
+  return `${String.fromCharCode("A".charCodeAt(0) + colNum - 1)}${rowNum}`
 }
 
 
@@ -159,13 +159,13 @@ function checkSheet(startRow = 2) {
   const categories = sheet.getRange(1, 3, 1, sheet.getLastColumn() - 2).getValues()[0]
 
   // Prefetch data
-  const allDatesRange = sheet.getRange(startRow, 2, sheet.getLastRow()-startRow+1, sheet.getLastColumn() - 1)
+  const allDatesRange = sheet.getRange(startRow, 2, sheet.getLastRow() - startRow + 1, sheet.getLastColumn() - 1)
   const allDatesValues = allDatesRange.getValues()
   const allDatesRtfs = allDatesRange.getRichTextValues()
   const allDatesNotes = allDatesRange.getNotes()
   const startDate = allDatesValues[0][0]
   let endDate = allDatesValues[allDatesValues.length - 1][0]
-  endDate.setDate(endDate.getDate()+1)
+  endDate.setDate(endDate.getDate() + 1)
   console.log(`Fetching events from ${startDate} to ${endDate}.`)
   const calendar = CalendarApp.getCalendarById(getSecrets().CALENDAR_ID)
   const allCalEvents = calendar.getEvents(startDate, endDate)
@@ -173,7 +173,7 @@ function checkSheet(startRow = 2) {
   // Iterate over each row
   for (let i = 0; i < allDatesValues.length; i++) {
     const sheetEvents = allDatesValues[i]
-    const calEvents = getEventsOnDate(allCalEvents, allDatesValues[i][0], categories);
+    const calEvents = getEventsOnDate(allCalEvents, sheetEvents[0], categories);
 
     // Iterate over each category
     for (let j = 0; j < categories.length; j++) {
@@ -284,10 +284,10 @@ function checkSheetNoPast() {
   const now = new Date();
   for (let i = 3; i < sheet.getLastRow() - 1; i++) {
     if (sheet.getRange(i, 2).getValue().getTime() >= now.getTime()) {
-      if (i-7 <= 3) {
+      if (i - 7 <= 3) {
         checkSheet(3)
       } else {
-        checkSheet(i-7)
+        checkSheet(i - 7)
       }
       break;
     }

--- a/calendar/calendar.gs
+++ b/calendar/calendar.gs
@@ -254,7 +254,9 @@ function hidePastRows() {
   // Hide rows in the past
   sheet.showRows(1, sheet.getLastRow());
   const today = new Date();
-  const first = today.getDate() - today.getDay() + 1;
+  let daysToRemove;
+  today.getDay() === 0 ? (daysToRemove = 7) : (daysToRemove = today.getDay())   // Sunday fix
+  const first = today.getDate() - daysToRemove + 1;
   const monday = new Date(today.setDate(first));
   for (let i = 3; i < sheet.getLastRow() - 1; i++) {
     if (sheet.getRange(i, 2).getValue().getTime() >= monday.getTime()) {

--- a/calendar/secrets.gs
+++ b/calendar/secrets.gs
@@ -13,6 +13,7 @@ function getSecrets() {
   const secrets = {};
   secrets.CALENDAR_ID = "calendarid@group.calendar.google.com"
   secrets.CELL_LINK_PREFIX = "https://docs.google.com/spreadsheets/d/sdfh45it87y540fyn4t5gf0985tgnb/edit#gid=0&range="
+  secrets.MULTI_EVENT_SPLITTER = "//"
   return secrets;
 
 }


### PR DESCRIPTION
Fixes #17. Multiple events in a single cell can be split up with the `secrets.MULTI_EVENT_SPLITTER` (a `//` by default). Whitespace around the title is trimmed.

Also fixed hiding past rows on a Sunday.