### PR TITLE
Added support for multi-day events with merged ranges

### DIFF
--- a/calendar/calendar.gs
+++ b/calendar/calendar.gs
@@ -9,6 +9,42 @@
 
 
 /**
+ * Get an object of the multi-day events.
+ *
+ * @param {SpreadsheetApp.Range} allDatesRange the calendar range
+ * @param {Array.<Array<any>>} allDatesValues the values of the calendar range
+ * @param {Array.<String>} categories the categories
+ * @param {number} startRow the row number to start on
+ * @returns {Object} an object of the milti-day events
+ */
+function getMergedEvents(allDatesRange, allDatesValues, categories, startRow) {
+
+  // Prep the result variable
+  let result = {}
+  for (c of categories) {
+    result[c] = {}
+  }
+
+  // Get the merged ranges
+  const mergedRanges = allDatesRange.getMergedRanges()
+
+  // Iterate over each one
+  for (let i = 0; i<mergedRanges.length; i++) {
+    const currentCategory = categories[mergedRanges[i].getColumn()-3]
+    const firstRowNum = mergedRanges[i].getRow()
+    const lastRowNum = mergedRanges[i].getLastRow()
+    const startDate = allDatesValues[firstRowNum-startRow][0]
+    const endDate = allDatesValues[lastRowNum-startRow][0]
+
+    result[currentCategory][startDate] = endDate;
+  }
+
+  console.log(result)
+
+}
+
+
+/**
  * Get the events on a date, returning them in an object.
  * The keys are the category names; the values are the arrays of events
  *
@@ -152,6 +188,8 @@ function getA1Notation(rowNum, colNum) {
 
 /**
  * Main function, updates Google Calendar with any changes.
+ *
+ * @param {number} startRow the row number to start on
  */
 function checkSheet(startRow = 2) {
 

--- a/calendar/calendar.gs
+++ b/calendar/calendar.gs
@@ -143,7 +143,8 @@ function generateDescription(cellNotation, cellRtf, cellNote) {
  *
  * Create an event from the cell in Google Calendar.
  *
- * @param {Date} eventDate the row number of the cell
+ * @param {Date} eventDate the start date
+ * @param {Date} endDate the end date
  * @param {String} cellValue the value of the cell
  * @param {String} cellNotation the A1 notation of the cell
  * @param {SpreadsheetApp.RichTextValue} cellRtf the RTF of the cell
@@ -151,11 +152,11 @@ function generateDescription(cellNotation, cellRtf, cellNote) {
  * @param {String} category the category of the event
  * @returns {CalendarApp.CalendarEvent} the created event
  */
-function createEventFromCell(eventDate, cellValue, cellNotation, cellRtf, cellNote, category) {
+function createEventFromCell(eventDate, endDate, cellValue, cellNotation, cellRtf, cellNote, category) {
   const calendar = CalendarApp.getCalendarById(getSecrets().CALENDAR_ID);
 
   // Create the event
-  const event = calendar.createAllDayEvent(`${cellValue} [${category.toLowerCase()}]`, eventDate)
+  const event = calendar.createAllDayEvent(`${cellValue} [${category.toLowerCase()}]`, eventDate, endDate)
   event.setTag("category", category)
   event.setLocation(getSecrets().CELL_LINK_PREFIX + cellNotation.replace(/:/g, ''))
   event.setDescription(generateDescription(cellNotation, cellRtf, cellNote))
@@ -168,19 +169,23 @@ function createEventFromCell(eventDate, cellValue, cellNotation, cellRtf, cellNo
 /**
  * Compare the sheet and calendar event.
  *
- * This compares by title and description.
+ * This compares by title, end date, and description.
  *
  * @param {CalendarApp.CalendarEvent} calEvent the calendar event
  * @param {String} cellValue the value of the cell
  * @param {String} cellNotation the A1 notation of the cell
  * @param {SpreadsheetApp.RichTextValue} cellRtf the RTF of the cell
  * @param {String} cellNote the cell note
+ * @param {Date} cellEndDate the end date based on cell merges
  * @param {String} category the category of the event
  * @returns {boolean} true if equal otherwise false
  */
-function compareEvents(calEvent, cellValue, cellNotation, cellRtf, cellNote, category) {
+function compareEvents(calEvent, cellValue, cellNotation, cellRtf, cellNote, cellEndDate,  category, ) {
   // False if the titles are different
   if (calEvent.getTitle() !== `${cellValue} [${category.toLowerCase()}]`) return false;
+
+  // False if the end dates are different (ignore times)
+  if (calEvent.getEndTime().toLocaleDateString("en-GB") !== cellEndDate.toLocaleDateString("en-GB")) return false;
 
   // False if the descriptions are different, otherwise true
   return calEvent.getDescription() === generateDescription(cellNotation, cellRtf, cellNote);

--- a/calendar/calendar.gs
+++ b/calendar/calendar.gs
@@ -16,10 +16,10 @@
  * @param {Number} days the number of days to add
  * @returns {Date} the modified date
  */
-Date.prototype.addDays = function(days) {
-    var date = new Date(this.valueOf());
-    date.setDate(date.getDate() + days);
-    return date;
+Date.prototype.addDays = function (days) {
+  let date = new Date(this.valueOf());
+  date.setDate(date.getDate() + days);
+  return date;
 }
 
 
@@ -30,7 +30,7 @@ Date.prototype.addDays = function(days) {
  * @param {Array.<Array<any>>} allDatesValues the values of the calendar range
  * @param {Array.<String>} categories the categories
  * @param {number} startRow the row number to start on
- * @returns {Object} an object of the milti-day events
+ * @returns {Object} an object of the multi-day events
  */
 function getMergedEvents(allDatesRange, allDatesValues, categories, startRow) {
 
@@ -44,16 +44,16 @@ function getMergedEvents(allDatesRange, allDatesValues, categories, startRow) {
   const mergedRanges = allDatesRange.getMergedRanges()
 
   // Iterate over each one
-  for (let i = 0; i<mergedRanges.length; i++) {
-    const currentCategory = categories[mergedRanges[i].getColumn()-3]
+  for (let i = 0; i < mergedRanges.length; i++) {
+    const currentCategory = categories[mergedRanges[i].getColumn() - 3]
     const firstRowNum = mergedRanges[i].getRow()
     const lastRowNum = mergedRanges[i].getLastRow()
-    const startDate = allDatesValues[firstRowNum-startRow][0]
-    const endDate = allDatesValues[lastRowNum-startRow][0].addDays(1)
-
+    const startDate = allDatesValues[firstRowNum - startRow][0]
+    const endDate = allDatesValues[lastRowNum - startRow][0].addDays(1)
     result[currentCategory][startDate] = endDate;
   }
 
+  console.log(`Multi-day events are ${JSON.stringify(result)}.`)
   return result
 
 }
@@ -82,7 +82,7 @@ function getEventsOnDate(allEvents, dateObj, categories) {
 
       const category = allEvents[i].getTag("category")
 
-      // If the category is valid and we don't have one for that category
+      // If the category is valid, and we don't have one for that category
       if (categories.includes(category) && eventsObj[category] === undefined) {
         eventsObj[category] = [allEvents[i]];
       } else if (categories.includes(category)) {
@@ -180,7 +180,7 @@ function createEventFromCell(eventDate, endDate, cellValue, cellNotation, cellRt
  * @param {String} category the category of the event
  * @returns {boolean} true if equal otherwise false
  */
-function compareEvents(calEvent, cellValue, cellNotation, cellRtf, cellNote, cellEndDate,  category, ) {
+function compareEvents(calEvent, cellValue, cellNotation, cellRtf, cellNote, cellEndDate, category) {
   // False if the titles are different
   if (calEvent.getTitle() !== `${cellValue} [${category.toLowerCase()}]`) return false;
 

--- a/calendar/calendar.gs
+++ b/calendar/calendar.gs
@@ -9,6 +9,21 @@
 
 
 /**
+ * Add days to a date.
+ *
+ * Credit to https://stackoverflow.com/a/563442/
+ *
+ * @param {Number} days the number of days to add
+ * @returns {Date} the modified date
+ */
+Date.prototype.addDays = function(days) {
+    var date = new Date(this.valueOf());
+    date.setDate(date.getDate() + days);
+    return date;
+}
+
+
+/**
  * Get an object of the multi-day events.
  *
  * @param {SpreadsheetApp.Range} allDatesRange the calendar range


### PR DESCRIPTION
Fixes #16. Multi-day events can be created by merging ranges. The data on merged ranges is fetched and organised at the start. 